### PR TITLE
use .gitconfig in USERPROFILE explicitely on Windows when HOME fails

### DIFF
--- a/R/whoami.R
+++ b/R/whoami.R
@@ -103,7 +103,20 @@ fullname <- function(fallback = NULL) {
       user <- system("git config --global user.name", intern = TRUE)
       user <- str_trim(user)
     }), silent = TRUE)
-    if (ok(user)) return(user)
+    if (ok(user)){
+      return(user)
+    } else{
+      user <- try(suppressWarnings({
+        user <- system(paste0("git config --file ",
+                              file.path(Sys.getenv("USERPROFILE"),
+                                        ".gitconfig"),
+                              " user.name"), intern = TRUE)
+        user <- str_trim(user)
+      }), silent = TRUE)
+      if(ok(user)){
+        return(user)
+      }
+    }
 
     user <- try({
       username <- username()

--- a/R/whoami.R
+++ b/R/whoami.R
@@ -146,7 +146,20 @@ fullname <- function(fallback = NULL) {
     user <- system("git config --global user.name", intern = TRUE)
     user <- str_trim(user)
   }), silent = TRUE)
-  if (ok(user)) return(user)
+  if (ok(user)){
+    return(user)
+  } else{
+    user <- try(suppressWarnings({
+      user <- system(paste0("git config --file ",
+                            file.path(Sys.getenv("USERPROFILE"),
+                                      ".gitconfig"),
+                            " user.name"), intern = TRUE)
+      user <- str_trim(user)
+    }), silent = TRUE)
+    if(ok(user)){
+      return(user)
+    }
+  }
 
   fallback_or_stop(fallback, "Cannot determine full name")
 }
@@ -171,7 +184,20 @@ email_address <- function(fallback = NULL) {
     email <- system("git config --global user.email", intern = TRUE)
     email <- str_trim(email)
   }), silent = TRUE)
-  if (ok(email)) return(email)
+  if (ok(email)){
+    return(email)
+  } else{
+    user <- try(suppressWarnings({
+      email <- system(paste0("git config --file ",
+                            file.path(Sys.getenv("USERPROFILE"),
+                                      ".gitconfig"),
+                            " user.email"), intern = TRUE)
+      email <- str_trim(email)
+    }), silent = TRUE)
+    if(ok(email)){
+      return(email)
+    }
+  }
 
   fallback_or_stop(fallback, "Cannot get email address")
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ or set to an empty string, then it tries running `id` on Unix-like
 systems and `whoami` on Windows.
 
 For the full name of the user, it queries the system services and
-also tries the user's global git configuration.
+also tries the user's global git configuration. On Windows, it tries finding the global git configuration in `Sys.getenv("USERPROFILE")` if it doesn't find it in `Sys.getenv("HOME")`.
 
 For the email address it users the user's global git configuration.
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -24,7 +24,7 @@ systems and `whoami` on Windows.
 For the full name of the user, it queries the system services and
 also tries the user's global git configuration. On Windows, it tries finding the global git configuration in `Sys.getenv("USERPROFILE")` if it doesn't find it in `Sys.getenv("HOME")`.
 
-For the email address it users the user's global git configuration.
+For the email address it uses the user's global git configuration. It tries finding the global git configuration in `Sys.getenv("USERPROFILE")` if it doesn't find it in `Sys.getenv("HOME")`.
 
 For the GitHub username it uses the `GITHUB_USERNAME` environment variable then it tries searching on GitHub for the user's email
 address.

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ or set to an empty string, then it tries running `id` on Unix-like
 systems and `whoami` on Windows.
 
 For the full name of the user, it queries the system services and
-also tries the user's global git configuration. On Windows, it tries finding the global git configuration in `Sys.getenv("USERPROFILE")` if it doesn't find it in `Sys.getenv("HOME")`.
+also tries the user's global git configuration. On Windows, it tries finding the global git configuration in `Sys.getenv("USERPROFILE")` if it doesn't find it in `Sys.getenv("HOME")` (often "Documents").
 
 For the email address it uses the user's global git configuration. It tries finding the global git configuration in `Sys.getenv("USERPROFILE")` if it doesn't find it in `Sys.getenv("HOME")`.
 


### PR DESCRIPTION
Cf #4 

I haven't added a test. I've deleted the copy of .gitconfig I had put in Documents/, and seen `whoami` now works.