### PR TITLE
add `fallback` to lookup_gh_username()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: whoami
 Title: Username, Full Name, Email Address, 'GitHub' Username of the Current User
-Version: 1.3.0
+Version: 1.3.0.9000
 Authors@R: c(person(given = "Gábor",
                     family = "Csárdi", 
                     email = "csardi.gabor@gmail.com", 

--- a/R/whoami.R
+++ b/R/whoami.R
@@ -272,14 +272,14 @@ gh_username <- function(token = NULL,
         "This does not seem to be an email address"
       ))
     }
-    lookup_gh_username(email, token)
+    lookup_gh_username(email, token, fallback)
 
   } else {
     fallback_or_stop(fallback, "Cannot get GitHub username")
   }
 }
 
-lookup_gh_username <- function(email, token) {
+lookup_gh_username <- function(email, token, fallback) {
   url <- URLencode(paste0(gh_url, "/search/users?q=", email,
                           " in:email"))
 

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,3 +1,6 @@
+# development version
+
+* `gh_username()` now supports `fallback` (#18, @dpprdan)
 
 # 1.3.0
 

--- a/tests/testthat/test-fallbacks.R
+++ b/tests/testthat/test-fallbacks.R
@@ -22,6 +22,9 @@ test_that("email_address() falls back", {
 
 test_that("gh_username() falls back", {
 
+  mockery::stub(gh_username, "me@example.com", "example e-mail")
+  expect_equal(gh_username(fallback = "example"), "example")
+
   mockery::stub(gh_username, "email_address", "not an email")
   expect_equal(gh_username(fallback = "foobar"), "foobar")
 


### PR DESCRIPTION
`fallback` is not passed through correctly to `lookup_gh_username()`, resulting in an uninformative `gh_username()` error.

``` r
whoami::gh_username(fallback = "my_fallback")
#> Error in fallback_or_stop(fallback, "Cannot find GitHub username for email"): object 'fallback' not found
```

This fix, ehm, fixes this

``` r
whoami::gh_username(fallback = "my_fallback")
#> [1] "my_fallback"
```
