### PR TITLE
omit `call.` from `stop()` in `fallback_or_stop()`

### DIFF
--- a/R/whoami.R
+++ b/R/whoami.R
@@ -40,7 +40,7 @@ fallback_or_stop <- function(fallback, msg) {
   if (!is.null(fallback)) {
     fallback
   } else {
-    stop(msg)
+    stop(msg, call. = FALSE)
   }
 }
 


### PR DESCRIPTION
Granted this depends on personal style, but IMHO seeing that the error was called by `fallback_or_stop()` doesn't add a lot of information. 😃 